### PR TITLE
Update fixing 302 issue and grammar in log message

### DIFF
--- a/aioptdevices/__main__.py
+++ b/aioptdevices/__main__.py
@@ -31,7 +31,7 @@ async def connect(
         LOGGER.warning("failed to connect to PTDevices server: %s", err)
 
     except aioptdevices.PTDevicesUnauthorizedError as err:
-        LOGGER.warning("Unable, to read device data because of bad token: %s", err)
+        LOGGER.warning("Unable to read device data because of bad token: %s", err)
 
     except aioptdevices.PTDevicesForbiddenError as err:
         LOGGER.warning("Unable, device does not belong to the token holder: %s", err)

--- a/aioptdevices/__main__.py
+++ b/aioptdevices/__main__.py
@@ -116,7 +116,7 @@ def starter():
 
     LOGGER.info("\n%s\n", "  ARGS  ".center(48, "-"))  # Output a section title for args
     LOGGER.info("deviceID: %s", args.deviceID)
-    LOGGER.info("Token: %s", args.authToken)
+    # LOGGER.info("Token: %s", args.authToken)
     LOGGER.info("url: %s", args.url)
     LOGGER.info("debug: %s", args.debug)
 

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -4,7 +4,6 @@ from http import HTTPStatus
 import logging
 from typing import Any, TypedDict
 
-from aiohttp import client_exceptions
 import orjson
 
 from aioptdevices.errors import (
@@ -54,28 +53,30 @@ class Interface:
             allow_redirects=False,
         ) as results:
             LOGGER.debug(
-                "%s Received from %s, %s", results.status, self.config.url, results
+                "%s Received from %s",
+                results.status,
+                self.config.url,
             )
 
             # Check return code
             if results.status == HTTPStatus.UNAUTHORIZED:  # 401
                 raise PTDevicesUnauthorizedError(
-                    f"Request to {url} failed, the token provided is not valid"
+                    f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid"
                 )
             elif results.status == HTTPStatus.FOUND:  # 302
                 # Back end currently returns a 302 when request is not authorized
                 raise PTDevicesUnauthorizedError(
-                    f"Request to {url} failed, the token provided is not valid (302)"
+                    f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid (302)"
                 )
 
             elif results.status == HTTPStatus.FORBIDDEN:  # 403
                 raise PTDevicesForbiddenError(
-                    f"Request to {url} failed, token invalid for device {self.config.device_id}"
+                    f"Request to {url.split('?api_token')[0]} failed, token invalid for device {self.config.device_id}"
                 )
 
             elif results.status != HTTPStatus.OK:  # anything but 200
                 raise PTDevicesRequestError(
-                    f"Request to {url} failed, got unexpected response from server ({results.status})"
+                    f"Request to {url.split('?api_token')[0]} failed, got unexpected response from server ({results.status})"
                 )
 
             # Check content type

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -51,6 +51,7 @@ class Interface:
         async with self.config.session.request(
             "get",
             url,
+            allow_redirects=False,
         ) as results:
             LOGGER.debug(
                 "%s Received from %s, %s", results.status, self.config.url, results
@@ -61,11 +62,11 @@ class Interface:
                 raise PTDevicesUnauthorizedError(
                     f"Request to {url} failed, the token provided is not valid"
                 )
-                # Check return code
-                if results.status == HTTPStatus.UNAUTHORIZED:  # 401
-                    raise PTDevicesUnauthorizedError(
-                        f"Request to {url} failed, the token provided is not valid"
-                    )
+            elif results.status == HTTPStatus.FOUND:  # 302
+                # Back end currently returns a 302 when request is not authorized
+                raise PTDevicesUnauthorizedError(
+                    f"Request to {url} failed, the token provided is not valid (302)"
+                )
 
             elif results.status == HTTPStatus.FORBIDDEN:  # 403
                 raise PTDevicesForbiddenError(

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -48,48 +48,49 @@ class Interface:
             self.config.device_id,
         )
 
-        try:
-            async with self.config.session.request(
-                "get",
-                url,
-            ) as results:
-                LOGGER.debug(
-                    "%s Received from %s, %s", results.status, self.config.url, results
-                )
+        async with self.config.session.request(
+            "get",
+            url,
+        ) as results:
+            LOGGER.debug(
+                "%s Received from %s, %s", results.status, self.config.url, results
+            )
 
+            # Check return code
+            if results.status == HTTPStatus.UNAUTHORIZED:  # 401
+                raise PTDevicesUnauthorizedError(
+                    f"Request to {url} failed, the token provided is not valid"
+                )
                 # Check return code
                 if results.status == HTTPStatus.UNAUTHORIZED:  # 401
                     raise PTDevicesUnauthorizedError(
                         f"Request to {url} failed, the token provided is not valid"
                     )
 
-                if results.status == HTTPStatus.FORBIDDEN:  # 403
-                    raise PTDevicesForbiddenError(
-                        f"Request to {url} failed, token invalid for device {self.config.device_id}"
-                    )
-
-                if results.status != HTTPStatus.OK:  # anything but 200
-                    raise PTDevicesRequestError(
-                        f"Request to {url} failed, got unexpected response from server ({results.status})"
-                    )
-
-                # Check content type
-                if (
-                    results.content_type != "application/json"
-                    or results.content_length == 0
-                ):
-                    raise PTDevicesRequestError(
-                        f"Failed to get device data, returned content is invalid. Type: {results.content_type}, content Length: {results.content_length}, content: {results.content}"
-                    )
-
-                raw_json = await results.read()
-
-                body = orjson.loads(raw_json)
-
-                return PTDevicesResponse(
-                    code=results.status,
-                    body=body["data"],
+            elif results.status == HTTPStatus.FORBIDDEN:  # 403
+                raise PTDevicesForbiddenError(
+                    f"Request to {url} failed, token invalid for device {self.config.device_id}"
                 )
 
-        except client_exceptions.ClientError as error:
-            raise PTDevicesRequestError(f"Request to {url} failed: {error}") from error
+            elif results.status != HTTPStatus.OK:  # anything but 200
+                raise PTDevicesRequestError(
+                    f"Request to {url} failed, got unexpected response from server ({results.status})"
+                )
+
+            # Check content type
+            elif (
+                results.content_type != "application/json"
+                or results.content_length == 0
+            ):
+                raise PTDevicesRequestError(
+                    f"Failed to get device data, returned content is invalid. Type: {results.content_type}, content Length: {results.content_length}, content: {results.content}"
+                )
+
+            raw_json = await results.read()
+
+            body = orjson.loads(raw_json)
+
+            return PTDevicesResponse(
+                code=results.status,
+                body=body["data"],
+            )


### PR DESCRIPTION
This update contains some minor fixes and improvements needed to move forward with the development of the Home Assistant integration.
## Fixes and Changes:
- Fixes issue where the API would try to redirect the session to the home page if the token is not valid for a given device. This is now handled by requesting that the session not be redirected, and catching the 302 in a new else if.
- Removed try-catch statement around the communication function. Catching of unhandled exceptions should be done by the calling program as it allows for more fine grained control of how they are handled in different use cases.
- Fixed a minor grammar issue in a log message.