### PR TITLE
Multi device (Breaking Changes)

### DIFF
--- a/aioptdevices/__main__.py
+++ b/aioptdevices/__main__.py
@@ -31,7 +31,7 @@ async def connect(
         LOGGER.warning("failed to connect to PTDevices server: %s", err)
 
     except aioptdevices.PTDevicesUnauthorizedError as err:
-        LOGGER.warning("Unable, to read device data because of bad token: %s", err)
+        LOGGER.warning("Unable to read device data because of bad token: %s", err)
 
     except aioptdevices.PTDevicesForbiddenError as err:
         LOGGER.warning("Unable, device does not belong to the token holder: %s", err)

--- a/aioptdevices/__main__.py
+++ b/aioptdevices/__main__.py
@@ -3,9 +3,9 @@
 import argparse
 import asyncio
 from asyncio.timeouts import timeout
+import json
 import logging
 
-import json
 from aiohttp import ClientSession, CookieJar
 
 import aioptdevices
@@ -16,18 +16,28 @@ LOGGER = logging.getLogger(__name__)
 
 
 async def connect(
-    deviceID: str, authToken: str, url: str, webSession: ClientSession
+    deviceID: str,
+    authToken: str,
+    url: str,
+    webSession: ClientSession,
 ) -> Interface | None:
     """Set up and Connect to PTDevices."""
 
     # Setup interface to PTDevices
     interface: Interface = Interface(
-        Configuration(authToken, deviceID, url, webSession)
+        Configuration(
+            authToken,
+            deviceID,
+            url,
+            webSession,
+        )
     )
     try:
         async with timeout(10):
             data = await interface.get_data()
-            LOGGER.info("Data: %s", data.get("body"))
+
+            formatted_body: str = json.dumps(data.get("body"), indent=2)
+            LOGGER.info("Data: %s", formatted_body)
     except aioptdevices.PTDevicesRequestError as err:
         LOGGER.warning("failed to connect to PTDevices server: %s", err)
 

--- a/aioptdevices/__main__.py
+++ b/aioptdevices/__main__.py
@@ -116,7 +116,7 @@ def starter():
 
     LOGGER.info("\n%s\n", "  ARGS  ".center(48, "-"))  # Output a section title for args
     LOGGER.info("deviceID: %s", args.deviceID)
-    LOGGER.info("Token: %s", args.authToken)
+    # LOGGER.info("Token: %s", args.authToken)
     LOGGER.info("url: %s", args.url)
     LOGGER.info("debug: %s", args.debug)
 

--- a/aioptdevices/__main__.py
+++ b/aioptdevices/__main__.py
@@ -5,6 +5,7 @@ import asyncio
 from asyncio.timeouts import timeout
 import logging
 
+import json
 from aiohttp import ClientSession, CookieJar
 
 import aioptdevices
@@ -90,12 +91,12 @@ async def main(
 
 def starter():
     """Parse CLI Arguments and fetch device data."""
-    default_url = "https://www.ptdevices.com/token/v1/device/"
+    default_url = "https://www.ptdevices.com/token/v1"
 
     # Parse cli args
     parser = argparse.ArgumentParser()
-    parser.add_argument("deviceID", type=int)
     parser.add_argument("authToken", type=str)
+    parser.add_argument("-I", "--id", type=str, default="")
     parser.add_argument("-U", "--url", type=str, default=default_url)
     parser.add_argument("-D", "--debug", action="store_true")
     args = parser.parse_args()
@@ -115,7 +116,7 @@ def starter():
     # --------------------  ARGS  --------------------
 
     LOGGER.info("\n%s\n", "  ARGS  ".center(48, "-"))  # Output a section title for args
-    LOGGER.info("deviceID: %s", args.deviceID)
+    LOGGER.info("deviceID: %s", args.id)
     # LOGGER.info("Token: %s", args.authToken)
     LOGGER.info("url: %s", args.url)
     LOGGER.info("debug: %s", args.debug)
@@ -124,7 +125,7 @@ def starter():
     try:
         asyncio.run(
             main(
-                deviceID=args.deviceID,
+                deviceID=args.id,
                 authToken=args.authToken,
                 url=args.url,
             )

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -4,7 +4,6 @@ from http import HTTPStatus
 import logging
 from typing import Any, TypedDict
 
-from aiohttp import client_exceptions
 import orjson
 
 from aioptdevices.errors import (
@@ -54,28 +53,30 @@ class Interface:
             allow_redirects=False,
         ) as results:
             LOGGER.debug(
-                "%s Received from %s, %s", results.status, self.config.url, results
+                "%s Received from %s",
+                results.status,
+                self.config.url,
             )
 
             # Check return code
             if results.status == HTTPStatus.UNAUTHORIZED:  # 401
                 raise PTDevicesUnauthorizedError(
-                    f"Request to {url} failed, the token provided is not valid"
+                    f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid"
                 )
             elif results.status == HTTPStatus.FOUND:  # 302
                 # Back end currently returns a 302 when request is not authorized
                 raise PTDevicesUnauthorizedError(
-                    f"Request to {url} failed, the token provided is not valid (302)"
+                    f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid (302)"
                 )
 
             elif results.status == HTTPStatus.FORBIDDEN:  # 403
                 raise PTDevicesForbiddenError(
-                    f"Request to {url} failed, token invalid for device {self.config.device_id}"
+                    f"Request to {url.split('?api_token')[0]} failed, token invalid for device {self.config.device_id}"
                 )
 
             elif results.status != HTTPStatus.OK:  # anything but 200
                 raise PTDevicesRequestError(
-                    f"Request to {url} failed, got unexpected response from server ({results.status})"
+                    f"Request to {url.split('?api_token')[0]} failed, got unexpected response from server ({results.status})"
                 )
 
             # Check content type

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -17,10 +17,13 @@ from .configuration import Configuration
 LOGGER = logging.getLogger(__name__)
 
 
+type PTDevicesResponseData = dict[str, Any] | list[dict[str, Any]]
+
+
 class PTDevicesResponse(TypedDict, total=False):
     """Typed Response from PTDevices."""
 
-    body: dict[str, Any]
+    body: PTDevicesResponseData
     code: int
 
 
@@ -74,24 +77,24 @@ class Interface:
                 raise PTDevicesUnauthorizedError(
                     f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid"
                 )
-            elif results.status == HTTPStatus.FOUND:  # 302
+            if results.status == HTTPStatus.FOUND:  # 302
                 # Back end currently returns a 302 when request is not authorized
                 raise PTDevicesUnauthorizedError(
                     f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid (302)"
                 )
 
-            elif results.status == HTTPStatus.FORBIDDEN:  # 403
+            if results.status == HTTPStatus.FORBIDDEN:  # 403
                 raise PTDevicesForbiddenError(
                     f"Request to {url.split('?api_token')[0]} failed, token invalid for device {self.config.device_id}"
                 )
 
-            elif results.status != HTTPStatus.OK:  # anything but 200
+            if results.status != HTTPStatus.OK:  # anything but 200
                 raise PTDevicesRequestError(
                     f"Request to {url.split('?api_token')[0]} failed, got unexpected response from server ({results.status})"
                 )
 
             # Check content type
-            elif (
+            if (
                 results.content_type != "application/json"
                 or results.content_length == 0
             ):

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -38,14 +38,25 @@ class Interface:
         #   {deviceId} is the numeric internal device id,
         #       found in the url https://www.ptdevices.com/device/level/{deviceId}
         #   {given_token} is the access token you were given
+        #
+        # Request url: https://api.ptdevices.com/token/v1/devices?api_token={given_token}
+        # Where
+        #   {given_token} is the access token you were given
 
-        url = f"{self.config.url}{self.config.device_id}?api_token={self.config.auth_token}"
-
-        LOGGER.debug(
-            "Sending request to %s for data from device #%s",
-            self.config.url,
-            self.config.device_id,
-        )
+        # Construct the URL differently for multi device and single device requests
+        if self.config.device_id == "*":
+            url = f"{self.config.url}/devices?api_token={self.config.auth_token}"
+            LOGGER.debug(
+                "Sending request to %s for data from all devices",
+                self.config.url,
+            )
+        else:
+            url = f"{self.config.url}/device/{self.config.device_id}?api_token={self.config.auth_token}"
+            LOGGER.debug(
+                "Sending request to %s for data from device %s",
+                self.config.url,
+                self.config.device_id,
+            )
 
         async with self.config.session.request(
             "get",

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -51,6 +51,7 @@ class Interface:
         async with self.config.session.request(
             "get",
             url,
+            allow_redirects=False,
         ) as results:
             LOGGER.debug(
                 "%s Received from %s, %s", results.status, self.config.url, results
@@ -61,11 +62,11 @@ class Interface:
                 raise PTDevicesUnauthorizedError(
                     f"Request to {url} failed, the token provided is not valid"
                 )
-                # Check return code
-                if results.status == HTTPStatus.UNAUTHORIZED:  # 401
-                    raise PTDevicesUnauthorizedError(
-                        f"Request to {url} failed, the token provided is not valid"
-                    )
+            elif results.status == HTTPStatus.FOUND:  # 302
+                # Back end currently returns a 302 when request is not authorized
+                raise PTDevicesUnauthorizedError(
+                    f"Request to {url} failed, the token provided is not valid (302)"
+                )
 
             elif results.status == HTTPStatus.FORBIDDEN:  # 403
                 raise PTDevicesForbiddenError(

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -48,48 +48,49 @@ class Interface:
             self.config.device_id,
         )
 
-        try:
-            async with self.config.session.request(
-                "get",
-                url,
-            ) as results:
-                LOGGER.debug(
-                    "%s Received from %s, %s", results.status, self.config.url, results
-                )
+        async with self.config.session.request(
+            "get",
+            url,
+        ) as results:
+            LOGGER.debug(
+                "%s Received from %s, %s", results.status, self.config.url, results
+            )
 
+            # Check return code
+            if results.status == HTTPStatus.UNAUTHORIZED:  # 401
+                raise PTDevicesUnauthorizedError(
+                    f"Request to {url} failed, the token provided is not valid"
+                )
                 # Check return code
                 if results.status == HTTPStatus.UNAUTHORIZED:  # 401
                     raise PTDevicesUnauthorizedError(
                         f"Request to {url} failed, the token provided is not valid"
                     )
 
-                if results.status == HTTPStatus.FORBIDDEN:  # 403
-                    raise PTDevicesForbiddenError(
-                        f"Request to {url} failed, token invalid for device {self.config.device_id}"
-                    )
-
-                if results.status != HTTPStatus.OK:  # anything but 200
-                    raise PTDevicesRequestError(
-                        f"Request to {url} failed, got unexpected response from server ({results.status})"
-                    )
-
-                # Check content type
-                if (
-                    results.content_type != "application/json"
-                    or results.content_length == 0
-                ):
-                    raise PTDevicesRequestError(
-                        f"Failed to get device data, returned content is invalid. Type: {results.content_type}, content Length: {results.content_length}, content: {results.content}"
-                    )
-
-                raw_json = await results.read()
-
-                body = orjson.loads(raw_json)
-
-                return PTDevicesResponse(
-                    code=results.status,
-                    body=body["data"],
+            elif results.status == HTTPStatus.FORBIDDEN:  # 403
+                raise PTDevicesForbiddenError(
+                    f"Request to {url} failed, token invalid for device {self.config.device_id}"
                 )
 
-        except client_exceptions.ClientError as error:
-            raise PTDevicesRequestError(f"Request to {url} failed: {error}") from error
+            elif results.status != HTTPStatus.OK:  # anything but 200
+                raise PTDevicesRequestError(
+                    f"Request to {url} failed, got unexpected response from server ({results.status})"
+                )
+
+            # Check content type
+            elif (
+                results.content_type != "application/json"
+                or results.content_length == 0
+            ):
+                raise PTDevicesRequestError(
+                    f"Failed to get device data, returned content is invalid. Type: {results.content_type}, content Length: {results.content_length}, content: {results.content}"
+                )
+
+            raw_json = await results.read()
+
+            body = orjson.loads(raw_json)
+
+            return PTDevicesResponse(
+                code=results.status,
+                body=body["data"],
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,19 @@ import pytest
 from .mock_api import (
     API_URL,
     BAD_GATEWAY_ERROR_DEVICE_ID,
+    EMPTY_ERROR_DEVICE_ID,
     FORBIDDEN_ERROR_DEVICE_ID,
     NORMAL_DEVICE_ID,
     NORMAL_DEVICE_MAC,
+    REDIRECT_ERROR_DEVICE_ID,
     UNAUTHORIZED_ERROR_DEVICE_ID,
     WRONG_CONTENT_TYPE_DEVICE_ID,
     bad_gateway_response,
     content_type_invalid_response,
+    empty_response,
     forbidden_response,
     good_response,
+    redirect_response,
     unauthorized_response,
 )
 
@@ -27,16 +31,29 @@ def test_web_app() -> web.Application:
     app.router.add_get(f"{API_URL}/device/{NORMAL_DEVICE_MAC}", good_response)  # type: ignore  # noqa: PGH003
 
     app.router.add_get(
-        f"{API_URL}/device/{UNAUTHORIZED_ERROR_DEVICE_ID}", unauthorized_response
+        f"{API_URL}/device/{EMPTY_ERROR_DEVICE_ID}",
+        empty_response,
+    )  # type: ignore  # noqa: PGH003
+
+    app.router.add_get(
+        f"{API_URL}/device/{UNAUTHORIZED_ERROR_DEVICE_ID}",
+        unauthorized_response,
     )  # type: ignore  # noqa: PGH003
     app.router.add_get(
-        f"{API_URL}/device/{FORBIDDEN_ERROR_DEVICE_ID}", forbidden_response
+        f"{API_URL}/device/{FORBIDDEN_ERROR_DEVICE_ID}",
+        forbidden_response,
     )  # type: ignore  # noqa: PGH003
     app.router.add_get(
-        f"{API_URL}/device/{BAD_GATEWAY_ERROR_DEVICE_ID}", bad_gateway_response
+        f"{API_URL}/device/{BAD_GATEWAY_ERROR_DEVICE_ID}",
+        bad_gateway_response,
     )  # type: ignore  # noqa: PGH003
     app.router.add_get(
-        f"{API_URL}/device{WRONG_CONTENT_TYPE_DEVICE_ID}", content_type_invalid_response
+        f"{API_URL}/device{WRONG_CONTENT_TYPE_DEVICE_ID}",
+        content_type_invalid_response,
+    )  # type: ignore  # noqa: PGH003
+    app.router.add_get(
+        f"{API_URL}/device/{REDIRECT_ERROR_DEVICE_ID}",
+        redirect_response,
     )  # type: ignore  # noqa: PGH003
 
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,12 +23,20 @@ from .mock_api import (
 def test_web_app() -> web.Application:
     """Create a test server for testing."""
     app = web.Application()
-    app.router.add_get(f"{API_URL}{NORMAL_DEVICE_ID}", good_response)  # type: ignore  # noqa: PGH003
-    app.router.add_get(f"{API_URL}{NORMAL_DEVICE_MAC}", good_response)  # type: ignore  # noqa: PGH003
+    app.router.add_get(f"{API_URL}/device/{NORMAL_DEVICE_ID}", good_response)  # type: ignore  # noqa: PGH003
+    app.router.add_get(f"{API_URL}/device/{NORMAL_DEVICE_MAC}", good_response)  # type: ignore  # noqa: PGH003
 
-    app.router.add_get(f"{API_URL}{UNAUTHORIZED_ERROR_DEVICE_ID}", unauthorized_response)  # type: ignore  # noqa: PGH003
-    app.router.add_get(f"{API_URL}{FORBIDDEN_ERROR_DEVICE_ID}", forbidden_response)  # type: ignore  # noqa: PGH003
-    app.router.add_get(f"{API_URL}{BAD_GATEWAY_ERROR_DEVICE_ID}", bad_gateway_response)  # type: ignore  # noqa: PGH003
-    app.router.add_get(f"{API_URL}{WRONG_CONTENT_TYPE_DEVICE_ID}", content_type_invalid_response)  # type: ignore  # noqa: PGH003
+    app.router.add_get(
+        f"{API_URL}/device/{UNAUTHORIZED_ERROR_DEVICE_ID}", unauthorized_response
+    )  # type: ignore  # noqa: PGH003
+    app.router.add_get(
+        f"{API_URL}/device/{FORBIDDEN_ERROR_DEVICE_ID}", forbidden_response
+    )  # type: ignore  # noqa: PGH003
+    app.router.add_get(
+        f"{API_URL}/device/{BAD_GATEWAY_ERROR_DEVICE_ID}", bad_gateway_response
+    )  # type: ignore  # noqa: PGH003
+    app.router.add_get(
+        f"{API_URL}/device{WRONG_CONTENT_TYPE_DEVICE_ID}", content_type_invalid_response
+    )  # type: ignore  # noqa: PGH003
 
     return app

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -5,10 +5,8 @@ from typing import Any
 from aiohttp import RequestInfo, web
 
 # Configs
-API_URL: str = "/token/v1/device/"  # Token API URL
-TOKEN: str = (
-    "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"  # fake token for testing
-)
+API_URL: str = "/token/v1"  # Token API URL
+TOKEN: str = "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"  # fake token for testing
 
 # Device IDs
 NORMAL_DEVICE_ID: str = "200"  # Always returns OK (200) and a good body
@@ -19,9 +17,7 @@ FORBIDDEN_ERROR_DEVICE_ID: str = "403"  # Always Returns a FORBIDDEN (403)
 BAD_GATEWAY_ERROR_DEVICE_ID: str = "502"  # Always Returns a BAD_GATEWAY (502)
 
 # Responses
-GOOD_RESP: str = (
-    '{"data":{"id":200,"device_id":"123456789ABC","share_id":"fFAa523e","created":"Jul 11th 2024, 7:44 PM","user_id":1234,"device_type":"level","title":"Test Response Level","version":"100","lat":null,"lng":null,"address":null,"status":"Working","delivery_notes":null,"units":"Metric","reported":"Jul 15th, 1:25 PM","tx_reported":"Jul 15th, 8:17 AM","last_updated_on":null,"wifi_signal":"100%","tx_signal":"-46.00dBm","device_data":{"percent_level":50,"battery_voltage":6.6,"battery_status":"Good","volume_level":100,"inch_level":10,"enclosure_temperature":22.2},"device_setup":{"depth":10,"power_x":30,"power_y":3048,"power_z":24,"shape":"rectangle","diameter":null,"width":null,"length":null},"temperature_units":"C"}}'
-)
+GOOD_RESP: str = '{"data":{"id":200,"device_id":"123456789ABC","share_id":"fFAa523e","created":"Jul 11th 2024, 7:44 PM","user_id":1234,"device_type":"level","title":"Test Response Level","version":"100","lat":null,"lng":null,"address":null,"status":"Working","delivery_notes":null,"units":"Metric","reported":"Jul 15th, 1:25 PM","tx_reported":"Jul 15th, 8:17 AM","last_updated_on":null,"wifi_signal":"100%","tx_signal":"-46.00dBm","device_data":{"percent_level":50,"battery_voltage":6.6,"battery_status":"Good","volume_level":100,"inch_level":10,"enclosure_temperature":22.2},"device_setup":{"depth":10,"power_x":30,"power_y":3048,"power_z":24,"shape":"rectangle","diameter":null,"width":null,"length":null},"temperature_units":"C"}}'
 
 GOOD_RESP_DICT: dict[str, Any] = {
     "data": {

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -11,8 +11,10 @@ TOKEN: str = "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b" 
 # Device IDs
 NORMAL_DEVICE_ID: str = "200"  # Always returns OK (200) and a good body
 NORMAL_DEVICE_MAC: str = "123456789ABC"
+EMPTY_ERROR_DEVICE_ID: str = "0"  # Always returns an empty (200)
 WRONG_CONTENT_TYPE_DEVICE_ID: str = "199"  # Same as NORMAL but wrong content type
 UNAUTHORIZED_ERROR_DEVICE_ID: str = "401"  # Always Returns an UNAUTHORIZED (401)
+REDIRECT_ERROR_DEVICE_ID: str = "302"  # Always Returns an FOUND (302)
 FORBIDDEN_ERROR_DEVICE_ID: str = "403"  # Always Returns a FORBIDDEN (403)
 BAD_GATEWAY_ERROR_DEVICE_ID: str = "502"  # Always Returns a BAD_GATEWAY (502)
 
@@ -70,6 +72,13 @@ async def good_response(request: RequestInfo) -> web.Response:
     return web.Response(status=200, content_type="application/json", body=GOOD_RESP)
 
 
+async def empty_response(request: RequestInfo) -> web.Response:
+    """Return an empty response (200)."""
+    assert request.url.query.get("api_token") == TOKEN  # Verify the token is valid
+
+    return web.Response(status=200, content_type="application/json", body="")
+
+
 async def content_type_invalid_response(request: RequestInfo) -> web.Response:
     """Return an OK (200) with the wrong content type."""
     return web.Response(status=200, body=GOOD_RESP)
@@ -95,18 +104,6 @@ async def not_found_response(request: RequestInfo) -> web.Response:
     return web.Response(status=404)
 
 
-# @pytest.fixture(name="test_web_app")
-# def test_web_app() -> web.Application:
-#     """Create a test server for testing."""
-#     app = web.Application()
-#     app.router.add_get(f"{API_URL}{NORMAL_DEVICE_ID}", good_response)  # type: ignore  # noqa: PGH003
-#     app.router.add_get(f"{API_URL}{NORMAL_DEVICE_MAC}", good_response)  # type: ignore  # noqa: PGH003
-
-#     app.router.add_get(f"{API_URL}{UNAUTHORIZED_ERROR_DEVICE_ID}", unauthorized_response)  # type: ignore  # noqa: PGH003
-#     app.router.add_get(f"{API_URL}{FORBIDDEN_ERROR_DEVICE_ID}", forbidden_response)  # type: ignore  # noqa: PGH003
-#     app.router.add_get(f"{API_URL}{BAD_GATEWAY_ERROR_DEVICE_ID}", bad_gateway_response)  # type: ignore  # noqa: PGH003
-#     app.router.add_get(f"{API_URL}{WRONG_CONTENT_TYPE_DEVICE_ID}", content_type_invalid_response)  # type: ignore  # noqa: PGH003
-
-#     # app.router.add_get("/", not_found_response)  # type: ignore  # noqa: PGH003  # If any other URL, return not found
-
-#     return app
+async def redirect_response(request: RequestInfo) -> web.Response:
+    """Return a PAGE NOT FOUND (302) to any request."""
+    return web.Response(status=302)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,5 @@
 """Tests for interface class."""
 
-from typing import Any
-
 from aiohttp import ClientSession, CookieJar
 from aiohttp.client_exceptions import InvalidUrlClientError
 from aiohttp.test_utils import TestClient, TestServer, loop_context
@@ -13,16 +11,18 @@ from aioptdevices.errors import (
     PTDevicesRequestError,
     PTDevicesUnauthorizedError,
 )
-from aioptdevices.interface import Interface, PTDevicesResponse
+from aioptdevices.interface import Interface, PTDevicesResponse, PTDevicesResponseData
 
 # Add your token and device ID, **keep out of git**
 from .mock_api import (
     API_URL,
     BAD_GATEWAY_ERROR_DEVICE_ID,
+    EMPTY_ERROR_DEVICE_ID,
     FORBIDDEN_ERROR_DEVICE_ID,
     GOOD_RESP_DICT,
     NORMAL_DEVICE_ID,
     NORMAL_DEVICE_MAC,
+    REDIRECT_ERROR_DEVICE_ID,
     TOKEN,
     UNAUTHORIZED_ERROR_DEVICE_ID,
     WRONG_CONTENT_TYPE_DEVICE_ID,
@@ -112,6 +112,12 @@ def test_resp_error_handling(test_web_app):
             with pytest.raises(PTDevicesForbiddenError):  # Test UNAUTHORIZED (401)
                 await interface.get_data()
 
+            # FORBIDDEN (302) Handling
+            interface: Interface = make_interface(REDIRECT_ERROR_DEVICE_ID)
+
+            with pytest.raises(PTDevicesUnauthorizedError):  # Test UNAUTHORIZED (401)
+                await interface.get_data()
+
             # PTDevicesRequestError (403) Handling
             interface: Interface = make_interface(BAD_GATEWAY_ERROR_DEVICE_ID)
 
@@ -120,6 +126,12 @@ def test_resp_error_handling(test_web_app):
 
             # Wrong content type Handling
             interface: Interface = make_interface(WRONG_CONTENT_TYPE_DEVICE_ID)
+
+            with pytest.raises(PTDevicesRequestError):  # Test UNAUTHORIZED (401)
+                await interface.get_data()
+
+            # FORBIDDEN (302) Handling
+            interface: Interface = make_interface(EMPTY_ERROR_DEVICE_ID)
 
             with pytest.raises(PTDevicesRequestError):  # Test UNAUTHORIZED (401)
                 await interface.get_data()
@@ -152,12 +164,12 @@ def test_real_server():
                 Configuration(
                     auth_token=secret_TOKEN,
                     device_id=secret_DEVICE_ID,
-                    url="https://api.ptdevices.com/token/v1/",
+                    url="https://api.ptdevices.com/token/v1",
                     session=session,
                 )
             )
             resp: PTDevicesResponse = await interface.get_data()
-            data: dict[str, Any] | None = resp.get("body")
+            data: PTDevicesResponseData = resp.get("body", {})
             assert data
             assert "device_id" in data
             await session.close()
@@ -165,34 +177,26 @@ def test_real_server():
         loop.run_until_complete(test_real_server())
 
 
-# interface: Interface = Interface(normal_config)
+def test_real_server_multi():
+    """Test the interface with the real server."""
+    with loop_context() as loop:
+        # Setup the test server
 
-# loop.run_until_complete(client.start_server())
+        async def test_real_server():
+            session: ClientSession = ClientSession(cookie_jar=CookieJar(unsafe=True))
+            interface: Interface = Interface(
+                Configuration(
+                    auth_token=secret_TOKEN,
+                    device_id="*",
+                    url="https://api.ptdevices.com/token/v1",
+                    session=session,
+                )
+            )
+            resp: PTDevicesResponse = await interface.get_data()
+            data: PTDevicesResponseData = resp.get("body", {})
+            assert data
+            assert type(data) is list
+            assert "device_id" in data[0]
+            await session.close()
 
-
-# def test_configuration(test_web_app):
-#     """Test the interface connection to a mock server."""
-#     with loop_context() as loop:
-#         server = TestServer(test_web_app)
-#         client = TestClient(server, loop=loop)
-#         loop.run_until_complete(client.start_server())
-
-#         async def test_get_routes():
-#             resp = await client.get(f"{API_URL}{NORMAL_DEVICE_ID}", params=query_params)
-
-#             # resp = await client.get(f"{API_URL}{NORMAL_DEVICE_ID}?api_token={TOKEN}")
-#             assert resp.status == 200
-#             resp = await client.get(
-#                 f"{API_URL}{BAD_GATEWAY_ERROR_DEVICE_ID}", params=query_params
-#             )
-#             assert resp.status == 502
-
-#         loop.run_until_complete(test_get_routes())
-#         loop.run_until_complete(client.close())
-
-# t_serv = test_server()
-# test_configuration: Configuration = Configuration(
-#     auth_token=
-#     device_id=
-
-# )
+        loop.run_until_complete(test_real_server())

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from aiohttp import ClientSession, CookieJar
+from aiohttp.client_exceptions import InvalidUrlClientError
 from aiohttp.test_utils import TestClient, TestServer, loop_context
 import pytest
 
@@ -48,7 +49,6 @@ def test_interface(test_web_app):
         interface: Interface = Interface(normal_config)
 
         async def test_get_data():
-
             resp: PTDevicesResponse = await interface.get_data()
             assert resp.get("body") == GOOD_RESP_DICT.get("data")
 
@@ -73,7 +73,6 @@ def test_mac_id(test_web_app):
         interface: Interface = Interface(normal_config)
 
         async def test_get_data():
-
             resp: PTDevicesResponse = await interface.get_data()
             assert resp.get("body") == GOOD_RESP_DICT.get("data")
 
@@ -135,7 +134,7 @@ def test_resp_error_handling(test_web_app):
                 )
             )
 
-            with pytest.raises(PTDevicesRequestError):  # Test UNAUTHORIZED (401)
+            with pytest.raises(InvalidUrlClientError):  # Test UNAUTHORIZED (401)
                 await interface.get_data()
 
         loop.run_until_complete(test_errors())
@@ -153,7 +152,7 @@ def test_real_server():
                 Configuration(
                     auth_token=secret_TOKEN,
                     device_id=secret_DEVICE_ID,
-                    url="http://www.ptdevices.com/token/v1/device/",
+                    url="https://api.ptdevices.com/token/v1/",
                     session=session,
                 )
             )


### PR DESCRIPTION
This update adds some new tests and a way to read the data of all devices registered to an account using the token

# BREAKING CHANGES

A new system is used for the URL parsing. Now, the URL passed to the configuration must be only the start. e.g. https://api.ptdevices.com/token/v1
The library will automatically add the rest of the path to the URL based on if the request is for a multi device, or a single device.

# Improvements:

The library now allows us to read the data of all devices on an account all at once. This is done by setting the device ID to "*" in the configuration. This returns a list of dict that contains the data for each device.