### PR TITLE
Keyed data and timeout (Breaking Changes)

### DIFF
--- a/aioptdevices/__main__.py
+++ b/aioptdevices/__main__.py
@@ -101,12 +101,12 @@ async def main(
 
 def starter():
     """Parse CLI Arguments and fetch device data."""
-    default_url = "https://www.ptdevices.com/token/v1"
+    default_url = "https://api.ptdevices.com/token/v1"
 
     # Parse cli args
     parser = argparse.ArgumentParser()
     parser.add_argument("authToken", type=str)
-    parser.add_argument("-I", "--id", type=str, default="")
+    parser.add_argument("-I", "--id", type=str, default="*")
     parser.add_argument("-U", "--url", type=str, default=default_url)
     parser.add_argument("-D", "--debug", action="store_true")
     args = parser.parse_args()

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -17,13 +17,10 @@ from .configuration import Configuration
 LOGGER = logging.getLogger(__name__)
 
 
-type PTDevicesResponseData = dict[str, Any] | list[dict[str, Any]]
-
-
 class PTDevicesResponse(TypedDict, total=False):
     """Typed Response from PTDevices."""
 
-    body: PTDevicesResponseData
+    body: dict[str, dict[str, Any]]
     code: int
 
 
@@ -106,7 +103,17 @@ class Interface:
 
             body = orjson.loads(raw_json)
 
-            return PTDevicesResponse(
-                code=results.status,
-                body=body["data"],
+                    # New formatting code
+                    formatted_body: dict[str, dict[str, Any]] = {
+                        device.get("device_id", ""): device
+                        for device in (
+                            body["data"]
+                            if type(body["data"]) is list
+                            else [body["data"]]
+                        )
+                    }
+
+                    # Store the new data to the response and return
+                    return PTDevicesResponse(code=results.status, body=formatted_body)
+
             )

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, TypedDict
 
 import orjson
+import asyncio
 
 from aioptdevices.errors import (
     PTDevicesForbiddenError,
@@ -58,50 +59,52 @@ class Interface:
                 self.config.device_id,
             )
 
-        async with self.config.session.request(
-            "get",
-            url,
-            allow_redirects=False,
-        ) as results:
-            LOGGER.debug(
-                "%s Received from %s",
-                results.status,
-                self.config.url,
-            )
+        try:
+            async with asyncio.timeout(10):
+                async with self.config.session.request(
+                    "get",
+                    url,
+                    allow_redirects=False,
+                ) as results:
+                    LOGGER.debug(
+                        "%s Received from %s",
+                        results.status,
+                        self.config.url,
+                    )
 
-            # Check return code
-            if results.status == HTTPStatus.UNAUTHORIZED:  # 401
-                raise PTDevicesUnauthorizedError(
-                    f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid"
-                )
-            if results.status == HTTPStatus.FOUND:  # 302
-                # Back end currently returns a 302 when request is not authorized
-                raise PTDevicesUnauthorizedError(
-                    f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid (302)"
-                )
+                    # Check return code
+                    if results.status == HTTPStatus.UNAUTHORIZED:  # 401
+                        raise PTDevicesUnauthorizedError(
+                            f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid"
+                        )
+                    if results.status == HTTPStatus.FOUND:  # 302
+                        # Back end currently returns a 302 when request is not authorized
+                        raise PTDevicesUnauthorizedError(
+                            f"Request to {url.split('?api_token')[0]} failed, the token provided is not valid (302)"
+                        )
 
-            if results.status == HTTPStatus.FORBIDDEN:  # 403
-                raise PTDevicesForbiddenError(
-                    f"Request to {url.split('?api_token')[0]} failed, token invalid for device {self.config.device_id}"
-                )
+                    if results.status == HTTPStatus.FORBIDDEN:  # 403
+                        raise PTDevicesForbiddenError(
+                            f"Request to {url.split('?api_token')[0]} failed, token invalid for device {self.config.device_id}"
+                        )
 
-            if results.status != HTTPStatus.OK:  # anything but 200
-                raise PTDevicesRequestError(
-                    f"Request to {url.split('?api_token')[0]} failed, got unexpected response from server ({results.status})"
-                )
+                    if results.status != HTTPStatus.OK:  # anything but 200
+                        raise PTDevicesRequestError(
+                            f"Request to {url.split('?api_token')[0]} failed, got unexpected response from server ({results.status})"
+                        )
 
-            # Check content type
-            if (
-                results.content_type != "application/json"
-                or results.content_length == 0
-            ):
-                raise PTDevicesRequestError(
-                    f"Failed to get device data, returned content is invalid. Type: {results.content_type}, content Length: {results.content_length}, content: {results.content}"
-                )
+                    # Check content type
+                    if (
+                        results.content_type != "application/json"
+                        or results.content_length == 0
+                    ):
+                        raise PTDevicesRequestError(
+                            f"Failed to get device data, returned content is invalid. Type: {results.content_type}, content Length: {results.content_length}, content: {results.content}"
+                        )
 
-            raw_json = await results.read()
+                    raw_json = await results.read()
 
-            body = orjson.loads(raw_json)
+                    body = orjson.loads(raw_json)
 
                     # New formatting code
                     formatted_body: dict[str, dict[str, Any]] = {
@@ -116,4 +119,8 @@ class Interface:
                     # Store the new data to the response and return
                     return PTDevicesResponse(code=results.status, body=formatted_body)
 
+        except TimeoutError:
+            # If the request timed out, throw a request error
+            raise PTDevicesRequestError(
+                f"Request to {url.split('?api_token')[0]} failed, request timed out"
             )

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -22,7 +22,7 @@ BAD_GATEWAY_ERROR_DEVICE_ID: str = "502"  # Always Returns a BAD_GATEWAY (502)
 GOOD_RESP: str = '{"data":{"id":200,"device_id":"123456789ABC","share_id":"fFAa523e","created":"Jul 11th 2024, 7:44 PM","user_id":1234,"device_type":"level","title":"Test Response Level","version":"100","lat":null,"lng":null,"address":null,"status":"Working","delivery_notes":null,"units":"Metric","reported":"Jul 15th, 1:25 PM","tx_reported":"Jul 15th, 8:17 AM","last_updated_on":null,"wifi_signal":"100%","tx_signal":"-46.00dBm","device_data":{"percent_level":50,"battery_voltage":6.6,"battery_status":"Good","volume_level":100,"inch_level":10,"enclosure_temperature":22.2},"device_setup":{"depth":10,"power_x":30,"power_y":3048,"power_z":24,"shape":"rectangle","diameter":null,"width":null,"length":null},"temperature_units":"C"}}'
 
 GOOD_RESP_DICT: dict[str, Any] = {
-    "data": {
+    "123456789ABC": {
         "id": 200,
         "device_id": "123456789ABC",
         "share_id": "fFAa523e",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,6 +4,7 @@ from aiohttp import ClientSession, CookieJar
 from aiohttp.client_exceptions import InvalidUrlClientError
 from aiohttp.test_utils import TestClient, TestServer, loop_context
 import pytest
+from typing import Any
 
 from aioptdevices.configuration import Configuration
 from aioptdevices.errors import (
@@ -11,7 +12,7 @@ from aioptdevices.errors import (
     PTDevicesRequestError,
     PTDevicesUnauthorizedError,
 )
-from aioptdevices.interface import Interface, PTDevicesResponse, PTDevicesResponseData
+from aioptdevices.interface import Interface, PTDevicesResponse
 
 # Add your token and device ID, **keep out of git**
 from .mock_api import (
@@ -50,7 +51,7 @@ def test_interface(test_web_app):
 
         async def test_get_data():
             resp: PTDevicesResponse = await interface.get_data()
-            assert resp.get("body") == GOOD_RESP_DICT.get("data")
+            assert resp.get("body") == GOOD_RESP_DICT
 
         loop.run_until_complete(test_get_data())
         loop.run_until_complete(client.close())
@@ -74,7 +75,7 @@ def test_mac_id(test_web_app):
 
         async def test_get_data():
             resp: PTDevicesResponse = await interface.get_data()
-            assert resp.get("body") == GOOD_RESP_DICT.get("data")
+            assert resp.get("body") == GOOD_RESP_DICT
 
         loop.run_until_complete(test_get_data())
         loop.run_until_complete(client.close())
@@ -169,9 +170,9 @@ def test_real_server():
                 )
             )
             resp: PTDevicesResponse = await interface.get_data()
-            data: PTDevicesResponseData = resp.get("body", {})
+            data: dict[str, dict[str, Any]] = resp.get("body", {})
             assert data
-            assert "device_id" in data
+            assert "device_id" in list(data.values())[0]
             await session.close()
 
         loop.run_until_complete(test_real_server())
@@ -193,10 +194,9 @@ def test_real_server_multi():
                 )
             )
             resp: PTDevicesResponse = await interface.get_data()
-            data: PTDevicesResponseData = resp.get("body", {})
+            data: dict[str, dict[str, Any]] = resp.get("body", {})
             assert data
-            assert type(data) is list
-            assert "device_id" in data[0]
+            assert "device_id" in list(data.values())[0]
             await session.close()
 
         loop.run_until_complete(test_real_server())


### PR DESCRIPTION
This update adds better formatting to the device data and timeout handling to the library.
The output data is now formatted with the mac address as a key for each device, seen below. This allows us to quickly find device information for a specific device if the ID is known. 

```json
{
    "MAC_ADDR": {
        "sensor_data1": 10,
        "sensor_data2": 2,
    },
    "MAC_ADDR2": {
        "sensor_data1": 10,
        "sensor_data2": 2,
    }
}
```

# BREAKING CHANGES

The response data for all types of queries (both single and multi-device) now return their results the same and missing the data key at the front. This will break current implementations of this library.

## New body data (single device):
```json
{
    "MAC_ADDR": {
        "sensor_data1": 10,
        "sensor_data2": 2,
    },
    "MAC_ADDR2": {
        "sensor_data1": 10,
        "sensor_data2": 2,
    }
}
```

## Old body data (single device):
```json
{
    "data": {
        "sensor_data1": 10,
        "sensor_data2": 2,
    }
}
```

# Improvements
The library now handles time out errors instead of relying on the calling program to do so. This cuts down on the code required to implement this library into a project.