### PR TITLE
snake_case formatting and unit conversion (Breaking Changes)

### DIFF
--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -28,6 +28,20 @@ class PTDevicesResponse(TypedDict, total=False):
     code: int
 
 
+class PTDevicesBatteryState(StrEnum):
+    """Store keys for hte different battery_status states."""
+
+    UNKNOWN = "unknown"
+    GOOD = "good"
+    LOW = "low"
+
+
+_battery_value_translations: dict[int, str] = {
+    1: PTDevicesBatteryState.GOOD,
+    2: PTDevicesBatteryState.LOW,
+}
+
+
 class PTDevicesStatusStates(StrEnum):
     """Store keys for the different device_status states."""
 
@@ -92,6 +106,14 @@ def _format_data(
             ]
         else:
             output[device_id]["status"] = PTDevicesStatusStates.UNKNOWN
+
+        # Translate the battery status number
+        if device["battery_status_number"] in _battery_value_translations.keys():
+            output[device_id]["battery_status"] = _battery_value_translations[
+                device["battery_status_number"]
+            ]
+        else:
+            output[device_id]["battery_status"] = PTDevicesBatteryState.UNKNOWN
 
     return output
 

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -17,6 +17,8 @@ from .configuration import Configuration
 
 LOGGER = logging.getLogger(__name__)
 
+type PTDevicesResponseData = dict[str, dict[str, Any]]
+
 
 class PTDevicesResponse(TypedDict, total=False):
     """Typed Response from PTDevices."""

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -108,12 +108,13 @@ def _format_data(
             output[device_id]["status"] = PTDevicesStatusStates.UNKNOWN
 
         # Translate the battery status number
-        if device["battery_status_number"] in _battery_value_translations.keys():
-            output[device_id]["battery_status"] = _battery_value_translations[
-                device["battery_status_number"]
-            ]
-        else:
-            output[device_id]["battery_status"] = PTDevicesBatteryState.UNKNOWN
+        if device.get("battery_status_number") is not None:
+            if device["battery_status_number"] in _battery_value_translations.keys():
+                output[device_id]["battery_status"] = _battery_value_translations[
+                    device["battery_status_number"]
+                ]
+            else:
+                output[device_id]["battery_status"] = PTDevicesBatteryState.UNKNOWN
 
     return output
 

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -7,6 +7,7 @@ from typing import Any, TypedDict
 
 import orjson
 import asyncio
+from string import ascii_letters
 
 from aioptdevices.errors import (
     PTDevicesForbiddenError,
@@ -66,6 +67,17 @@ _status_value_translations: dict[int, str] = {
     6: PTDevicesStatusStates.PRESS_TRANSMITTER_CONNECT_BUTTON,
 }
 
+_convert_to_number_keys: dict[str, type] = {
+    "version": int,
+    "wifi_signal": int,
+    "tx_signal": float,
+    "percent_level": float,
+    "battery_voltage": float,
+    "volume_level": float,
+    "inch_level": float,
+    "probe_temperature": float,
+}
+
 
 def _format_data(
     input: list[dict[str, Any]],
@@ -115,6 +127,35 @@ def _format_data(
                 ]
             else:
                 output[device_id]["battery_status"] = PTDevicesBatteryState.UNKNOWN
+
+        # Change all measurements to float | int | str
+        for key in _convert_to_number_keys.keys():
+            if device.get(key) is not None and isinstance(device.get(key), str):
+                output[device_id][key] = float(
+                    device.get(key, "").strip(ascii_letters + "%")
+                )
+
+        # Change all measurements to metric
+        if device.get("percent_level") is not None:
+            output[device_id]["inch_level"] = 0.0254 * float(
+                device.get("inch_level", 0.0)
+            )
+
+            if device.get("units", "") == "US Imperial":
+                output[device_id]["volume_level"] = 3.785411784 * float(
+                    device.get("volume_level", 0.0)
+                )
+
+            if device.get("units", "") == "British Imperial":
+                output[device_id]["volume_level"] = 4.54609 * float(
+                    device.get("volume_level", 0.0)
+                )
+
+        if device.get("probe_temperature") is not None:
+            if device.get("temperature_units", "") == "F":
+                output[device_id]["probe_temperature"] = (
+                    float(device.get("probe_temperature", 0.0)) - 32
+                ) * 0.5555555556
 
     return output
 

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -113,20 +113,24 @@ def _format_data(
     for device_id, device in output.items():
         # Translate the device status number
         if device["status_number"] in _status_value_translations.keys():
-            output[device_id]["status"] = _status_value_translations[
-                device["status_number"]
-            ]
+            output[device_id]["status"] = str(
+                _status_value_translations[device["status_number"]]
+            )
         else:
-            output[device_id]["status"] = PTDevicesStatusStates.UNKNOWN
+            output[device_id]["status"] = str(
+                PTDevicesStatusStates.UNKNOWN
+            )  # TODO tests dont cover this
 
         # Translate the battery status number
         if device.get("battery_status_number") is not None:
             if device["battery_status_number"] in _battery_value_translations.keys():
-                output[device_id]["battery_status"] = _battery_value_translations[
-                    device["battery_status_number"]
-                ]
+                output[device_id]["battery_status"] = str(
+                    _battery_value_translations[device["battery_status_number"]]
+                )
             else:
-                output[device_id]["battery_status"] = PTDevicesBatteryState.UNKNOWN
+                output[device_id]["battery_status"] = str(
+                    PTDevicesBatteryState.UNKNOWN
+                )  # TODO tests dont cover this
 
         # Change all measurements to float | int | str
         for key in _convert_to_number_keys.keys():
@@ -137,25 +141,25 @@ def _format_data(
 
         # Change all measurements to metric
         if device.get("percent_level") is not None:
-            output[device_id]["inch_level"] = 0.0254 * float(
-                device.get("inch_level", 0.0)
+            output[device_id]["inch_level"] = round(
+                0.0254 * float(device.get("inch_level", 0.0)), 6
             )
 
             if device.get("units", "") == "US Imperial":
-                output[device_id]["volume_level"] = 3.785411784 * float(
-                    device.get("volume_level", 0.0)
+                output[device_id]["volume_level"] = round(
+                    3.785411784 * float(device.get("volume_level", 0.0)), 6
                 )
 
             if device.get("units", "") == "British Imperial":
-                output[device_id]["volume_level"] = 4.54609 * float(
-                    device.get("volume_level", 0.0)
+                output[device_id]["volume_level"] = round(
+                    4.54609 * float(device.get("volume_level", 0.0)), 6
                 )
 
         if device.get("probe_temperature") is not None:
             if device.get("temperature_units", "") == "F":
-                output[device_id]["probe_temperature"] = (
-                    float(device.get("probe_temperature", 0.0)) - 32
-                ) * 0.5555555556
+                output[device_id]["probe_temperature"] = round(
+                    (float(device.get("probe_temperature", 0.0)) - 32) * 0.5555555556, 3
+                )
 
     return output
 

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -131,8 +131,8 @@ def _format_data(
         # Change all measurements to float | int | str
         for key in _convert_to_number_keys.keys():
             if device.get(key) is not None and isinstance(device.get(key), str):
-                output[device_id][key] = float(
-                    device.get(key, "").strip(ascii_letters + "%")
+                output[device_id][key] = _convert_to_number_keys[key](
+                    device.get(key, "").strip(ascii_letters + "%"),
                 )
 
         # Change all measurements to metric

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -1,5 +1,6 @@
 """Python Library for communicating with PTDevices."""
 
+from enum import StrEnum
 from http import HTTPStatus
 import logging
 from typing import Any, TypedDict
@@ -25,6 +26,26 @@ class PTDevicesResponse(TypedDict, total=False):
 
     body: dict[str, dict[str, Any]]
     code: int
+
+
+class PTDevicesStatusStates(StrEnum):
+    """Store keys for the different device_status states."""
+
+    UNKNOWN = "unknown"
+    WORKING = "working"
+    NOT_CONNECTED_YET = "not_connected_yet"
+    NOT_CONNECTED = "not_connected"
+    TRANSMITTER_NOT_REPORTING = "transmitter_not_reporting"
+    PRESS_TRANSMITTER_CONNECT_BUTTON = "press_transmitter_connect_button"
+
+
+_value_translations: dict[str, str] = {
+    "Working": PTDevicesStatusStates.WORKING,
+    "Not Connected Yet": PTDevicesStatusStates.NOT_CONNECTED_YET,
+    "Not Connected": PTDevicesStatusStates.NOT_CONNECTED,
+    "Transmitter Not Reporting": PTDevicesStatusStates.TRANSMITTER_NOT_REPORTING,
+    "Press Transmitter Connect Button": PTDevicesStatusStates.PRESS_TRANSMITTER_CONNECT_BUTTON,
+}
 
 
 def _format_data(
@@ -54,6 +75,17 @@ def _format_data(
 
     for device_id, device in devices.items():
         output[device_id] = recurse(device)
+
+    # At this point the data has been transformed into a flat dict
+    # {"id":{...info...},"id2":{...info...}}
+
+    for device_id, device in output.items():
+        if device["status"] in _value_translations.keys():
+            output[device_id]["status"] = _value_translations[
+                output[device_id]["status"]
+            ]
+        else:
+            output[device_id]["status"] = PTDevicesStatusStates.UNKNOWN
 
     return output
 

--- a/aioptdevices/interface.py
+++ b/aioptdevices/interface.py
@@ -37,14 +37,19 @@ class PTDevicesStatusStates(StrEnum):
     NOT_CONNECTED = "not_connected"
     TRANSMITTER_NOT_REPORTING = "transmitter_not_reporting"
     PRESS_TRANSMITTER_CONNECT_BUTTON = "press_transmitter_connect_button"
+    POWER_INTERNET_OUT_OR_RECEIVER_NOT_WORKING = (
+        "power_internet_out_or_receiver_not_working"
+    )
 
 
-_value_translations: dict[str, str] = {
-    "Working": PTDevicesStatusStates.WORKING,
-    "Not Connected Yet": PTDevicesStatusStates.NOT_CONNECTED_YET,
-    "Not Connected": PTDevicesStatusStates.NOT_CONNECTED,
-    "Transmitter Not Reporting": PTDevicesStatusStates.TRANSMITTER_NOT_REPORTING,
-    "Press Transmitter Connect Button": PTDevicesStatusStates.PRESS_TRANSMITTER_CONNECT_BUTTON,
+_status_value_translations: dict[int, str] = {
+    0: PTDevicesStatusStates.NOT_CONNECTED_YET,
+    1: PTDevicesStatusStates.NOT_CONNECTED_YET,
+    2: PTDevicesStatusStates.WORKING,
+    3: PTDevicesStatusStates.NOT_CONNECTED,
+    4: PTDevicesStatusStates.TRANSMITTER_NOT_REPORTING,
+    5: PTDevicesStatusStates.POWER_INTERNET_OUT_OR_RECEIVER_NOT_WORKING,
+    6: PTDevicesStatusStates.PRESS_TRANSMITTER_CONNECT_BUTTON,
 }
 
 
@@ -80,9 +85,10 @@ def _format_data(
     # {"id":{...info...},"id2":{...info...}}
 
     for device_id, device in output.items():
-        if device["status"] in _value_translations.keys():
-            output[device_id]["status"] = _value_translations[
-                output[device_id]["status"]
+        # Translate the device status number
+        if device["status_number"] in _status_value_translations.keys():
+            output[device_id]["status"] = _status_value_translations[
+                device["status_number"]
             ]
         else:
             output[device_id]["status"] = PTDevicesStatusStates.UNKNOWN

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ from .mock_api import (
     EMPTY_ERROR_DEVICE_ID,
     FORBIDDEN_ERROR_DEVICE_ID,
     NORMAL_DEVICE_ID,
+    NORMAL_DEVICE_ID_US,
+    NORMAL_DEVICE_ID_UK,
     NORMAL_DEVICE_MAC,
     REDIRECT_ERROR_DEVICE_ID,
     UNAUTHORIZED_ERROR_DEVICE_ID,
@@ -18,6 +20,8 @@ from .mock_api import (
     empty_response,
     forbidden_response,
     good_response,
+    good_response_us_imperial_conversions,
+    good_response_uk_imperial_conversions,
     redirect_response,
     unauthorized_response,
 )
@@ -29,6 +33,14 @@ def test_web_app() -> web.Application:
     app = web.Application()
     app.router.add_get(f"{API_URL}/device/{NORMAL_DEVICE_ID}", good_response)  # type: ignore  # noqa: PGH003
     app.router.add_get(f"{API_URL}/device/{NORMAL_DEVICE_MAC}", good_response)  # type: ignore  # noqa: PGH003
+    app.router.add_get(
+        f"{API_URL}/device/{NORMAL_DEVICE_ID_US}",
+        good_response_us_imperial_conversions,
+    )  # type: ignore  # noqa: PGH003
+    app.router.add_get(
+        f"{API_URL}/device/{NORMAL_DEVICE_ID_UK}",
+        good_response_uk_imperial_conversions,
+    )  # type: ignore  # noqa: PGH003
 
     app.router.add_get(
         f"{API_URL}/device/{EMPTY_ERROR_DEVICE_ID}",

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -11,6 +11,8 @@ TOKEN: str = "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b" 
 # Device IDs
 NORMAL_DEVICE_ID: str = "200"  # Always returns OK (200) and a good body
 NORMAL_DEVICE_MAC: str = "123456789ABC"
+NORMAL_DEVICE_ID_US: str = "200US"
+NORMAL_DEVICE_ID_UK: str = "200UK"
 EMPTY_ERROR_DEVICE_ID: str = "0"  # Always returns an empty (200)
 WRONG_CONTENT_TYPE_DEVICE_ID: str = "199"  # Same as NORMAL but wrong content type
 UNAUTHORIZED_ERROR_DEVICE_ID: str = "401"  # Always Returns an UNAUTHORIZED (401)
@@ -19,7 +21,9 @@ FORBIDDEN_ERROR_DEVICE_ID: str = "403"  # Always Returns a FORBIDDEN (403)
 BAD_GATEWAY_ERROR_DEVICE_ID: str = "502"  # Always Returns a BAD_GATEWAY (502)
 
 # Responses
-GOOD_RESP: str = '{"data":{"id":200,"device_id":"123456789ABC","share_id":"fFAa523e","created":"Jul 11th 2024, 7:44 PM","user_id":1234,"device_type":"level","title":"Test Response Level","version":"100","lat":null,"lng":null,"address":null,"status":"Working","delivery_notes":null,"units":"Metric","reported":"Jul 15th, 1:25 PM","tx_reported":"Jul 15th, 8:17 AM","last_updated_on":null,"wifi_signal":"100%","tx_signal":"-46.00dBm","device_data":{"percent_level":50,"battery_voltage":6.6,"battery_status":"Good","volume_level":100,"inch_level":10,"enclosure_temperature":22.2},"device_setup":{"depth":10,"power_x":30,"power_y":3048,"power_z":24,"shape":"rectangle","diameter":null,"width":null,"length":null},"temperature_units":"C"}}'
+GOOD_RESP: str = '{"data":{"id":200,"device_id":"123456789ABC","share_id":"fFAa523e","created":"Jul 11th 2024, 7:44 PM","user_id":1234,"device_type":"level","title":"Test Response Level","version":"100","lat":null,"lng":null,"address":null,"status":"Working","status_number":2,"delivery_notes":null,"units":"Metric","reported":"Jul 15th, 1:25 PM","tx_reported":"Jul 15th, 8:17 AM","last_updated_on":null,"wifi_signal":"100%","tx_signal":"-46.00dBm","device_data":{"percent_level":50,"battery_voltage":6.6,"battery_status":"Good","battery_status_number":1,"volume_level":100,"inch_level":10,"enclosure_temperature":22.2},"device_setup":{"depth":10,"power_x":30,"power_y":3048,"power_z":24,"shape":"rectangle","diameter":null,"width":null,"length":null},"temperature_units":"C"}}'
+GOOD_RESP_US_IMP: str = '{"data":{"id":200,"device_id":"123456789ABC","share_id":"fFAa523e","created":"Jul 11th 2024, 7:44 PM","user_id":1234,"device_type":"level","title":"Test Response Level","version":"100","lat":null,"lng":null,"address":null,"status":"Working","status_number":2,"delivery_notes":null,"units":"US Imperial","reported":"Jul 15th, 1:25 PM","tx_reported":"Jul 15th, 8:17 AM","last_updated_on":null,"wifi_signal":"100%","tx_signal":"-46.00dBm","device_data":{"percent_level":50,"battery_voltage":6.6,"battery_status":"Good","battery_status_number":1,"volume_level":100,"inch_level":10,"enclosure_temperature":22.2,"probe_temperature":70},"device_setup":{"depth":10,"power_x":30,"power_y":3048,"power_z":24,"shape":"rectangle","diameter":null,"width":null,"length":null},"temperature_units":"F"}}'
+GOOD_RESP_UK_IMP: str = '{"data":{"id":200,"device_id":"123456789ABC","share_id":"fFAa523e","created":"Jul 11th 2024, 7:44 PM","user_id":1234,"device_type":"level","title":"Test Response Level","version":"100","lat":null,"lng":null,"address":null,"status":"Working","status_number":2,"delivery_notes":null,"units":"British Imperial","reported":"Jul 15th, 1:25 PM","tx_reported":"Jul 15th, 8:17 AM","last_updated_on":null,"wifi_signal":"100%","tx_signal":"-46.00dBm","device_data":{"percent_level":50,"battery_voltage":6.6,"battery_status":"Good","battery_status_number":1,"volume_level":100,"inch_level":10,"enclosure_temperature":22.2},"device_setup":{"depth":10,"power_x":30,"power_y":3048,"power_z":24,"shape":"rectangle","diameter":null,"width":null,"length":null},"temperature_units":"F"}}'
 
 GOOD_RESP_DICT: dict[str, Any] = {
     "123456789ABC": {
@@ -30,23 +34,25 @@ GOOD_RESP_DICT: dict[str, Any] = {
         "user_id": 1234,
         "device_type": "level",
         "title": "Test Response Level",
-        "version": "100",
+        "version": 100,
         "lat": None,
         "lng": None,
         "address": None,
-        "status": "Working",
+        "status": "working",
+        "status_number": 2,
         "delivery_notes": None,
         "units": "Metric",
         "reported": "Jul 15th, 1:25 PM",
         "tx_reported": "Jul 15th, 8:17 AM",
         "last_updated_on": None,
-        "wifi_signal": "100%",
-        "tx_signal": "-46.00dBm",
+        "wifi_signal": 100,
+        "tx_signal": -46.00,
         "percent_level": 50,
         "battery_voltage": 6.6,
-        "battery_status": "Good",
+        "battery_status": "good",
+        "battery_status_number": 1,
         "volume_level": 100,
-        "inch_level": 10,
+        "inch_level": 0.254,
         "enclosure_temperature": 22.2,
         "depth": 10,
         "power_x": 30,
@@ -60,12 +66,113 @@ GOOD_RESP_DICT: dict[str, Any] = {
     }
 }
 
+GOOD_RESP_DICT_US_IMP: dict[str, Any] = {
+    "123456789ABC": {
+        "id": 200,
+        "device_id": "123456789ABC",
+        "share_id": "fFAa523e",
+        "created": "Jul 11th 2024, 7:44 PM",
+        "user_id": 1234,
+        "device_type": "level",
+        "title": "Test Response Level",
+        "version": 100,
+        "lat": None,
+        "lng": None,
+        "address": None,
+        "status": "working",
+        "status_number": 2,
+        "delivery_notes": None,
+        "units": "US Imperial",
+        "reported": "Jul 15th, 1:25 PM",
+        "tx_reported": "Jul 15th, 8:17 AM",
+        "last_updated_on": None,
+        "wifi_signal": 100,
+        "tx_signal": -46.00,
+        "percent_level": 50,
+        "battery_voltage": 6.6,
+        "battery_status": "good",
+        "battery_status_number": 1,
+        "volume_level": 378.541178,
+        "inch_level": 0.254,
+        "enclosure_temperature": 22.2,
+        "probe_temperature": 21.111,
+        "depth": 10,
+        "power_x": 30,
+        "power_y": 3048,
+        "power_z": 24,
+        "shape": "rectangle",
+        "diameter": None,
+        "width": None,
+        "length": None,
+        "temperature_units": "F",
+    }
+}
+
+GOOD_RESP_DICT_UK_IMP: dict[str, Any] = {
+    "123456789ABC": {
+        "id": 200,
+        "device_id": "123456789ABC",
+        "share_id": "fFAa523e",
+        "created": "Jul 11th 2024, 7:44 PM",
+        "user_id": 1234,
+        "device_type": "level",
+        "title": "Test Response Level",
+        "version": 100,
+        "lat": None,
+        "lng": None,
+        "address": None,
+        "status": "working",
+        "status_number": 2,
+        "delivery_notes": None,
+        "units": "British Imperial",
+        "reported": "Jul 15th, 1:25 PM",
+        "tx_reported": "Jul 15th, 8:17 AM",
+        "last_updated_on": None,
+        "wifi_signal": 100,
+        "tx_signal": -46.00,
+        "percent_level": 50,
+        "battery_voltage": 6.6,
+        "battery_status": "good",
+        "battery_status_number": 1,
+        "volume_level": 454.609,
+        "inch_level": 0.254,
+        "enclosure_temperature": 22.2,
+        "depth": 10,
+        "power_x": 30,
+        "power_y": 3048,
+        "power_z": 24,
+        "shape": "rectangle",
+        "diameter": None,
+        "width": None,
+        "length": None,
+        "temperature_units": "F",
+    }
+}
+
 
 async def good_response(request: RequestInfo) -> web.Response:
     """Return an OK (200)."""
     assert request.url.query.get("api_token") == TOKEN  # Verify the token is matching
 
     return web.Response(status=200, content_type="application/json", body=GOOD_RESP)
+
+
+async def good_response_us_imperial_conversions(request: RequestInfo) -> web.Response:
+    """Return an OK (200)."""
+    assert request.url.query.get("api_token") == TOKEN  # Verify the token is matching
+
+    return web.Response(
+        status=200, content_type="application/json", body=GOOD_RESP_US_IMP
+    )
+
+
+async def good_response_uk_imperial_conversions(request: RequestInfo) -> web.Response:
+    """Return an OK (200)."""
+    assert request.url.query.get("api_token") == TOKEN  # Verify the token is matching
+
+    return web.Response(
+        status=200, content_type="application/json", body=GOOD_RESP_UK_IMP
+    )
 
 
 async def empty_response(request: RequestInfo) -> web.Response:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -22,7 +22,11 @@ from .mock_api import (
     EMPTY_ERROR_DEVICE_ID,
     FORBIDDEN_ERROR_DEVICE_ID,
     GOOD_RESP_DICT,
+    GOOD_RESP_DICT_US_IMP,
+    GOOD_RESP_DICT_UK_IMP,
     NORMAL_DEVICE_ID,
+    NORMAL_DEVICE_ID_US,
+    NORMAL_DEVICE_ID_UK,
     NORMAL_DEVICE_MAC,
     REDIRECT_ERROR_DEVICE_ID,
     TOKEN,
@@ -79,6 +83,46 @@ def test_mac_id(test_web_app):
             assert resp.get("body") == GOOD_RESP_DICT
 
         loop.run_until_complete(test_get_data())
+        loop.run_until_complete(client.close())
+
+
+def test_unit_conversion(test_web_app):
+    """Test the automatic unit conversion."""
+    with loop_context() as loop:
+        # Setup the test server
+        server = TestServer(test_web_app)
+        client = TestClient(server, loop=loop)
+        loop.run_until_complete(client.start_server())
+
+        # Test US Units
+        normal_config: Configuration = Configuration(
+            auth_token=TOKEN,
+            device_id=NORMAL_DEVICE_ID_US,
+            url=str(client.make_url(API_URL)),
+            session=client.session,
+        )
+        interface: Interface = Interface(normal_config)
+
+        async def test_get_data_us():
+            resp: PTDevicesResponse = await interface.get_data()
+            assert resp.get("body") == GOOD_RESP_DICT_US_IMP
+
+        loop.run_until_complete(test_get_data_us())
+
+        # Test UK Units
+        normal_config: Configuration = Configuration(
+            auth_token=TOKEN,
+            device_id=NORMAL_DEVICE_ID_UK,
+            url=str(client.make_url(API_URL)),
+            session=client.session,
+        )
+        interface: Interface = Interface(normal_config)
+
+        async def test_get_data_uk():
+            resp: PTDevicesResponse = await interface.get_data()
+            assert resp.get("body") == GOOD_RESP_DICT_UK_IMP
+
+        loop.run_until_complete(test_get_data_uk())
         loop.run_until_complete(client.close())
 
 


### PR DESCRIPTION
This update improves and simplifies the use of the library through multiple means:
- The library now converts the response into a more useful format for home assistant. This is done by translating the status and battery_status values to use a snake_case format instead.
- The device readings are now converted to metric no matter what units are selected on PTDevices.com. This significantly reduces code complexity in home assistant and allows the conversion to take place by home assistant instead of depending on PTDevices.
- Test Coverage has been updated to cover most of the new additions.
# BREAKING CHANGES
Due to the nature of this update, there will be multiple functions of the library that will no longer work the same. The reason for these changes was highlighted above. The main fields that were changed are:
```diff
{
    "123456789ABC": {
       "id": 200,
        "device_id": "123456789ABC",
        "share_id": "fFAa523e",
        "created": "Jul 11th 2024, 7:44 PM",
        "user_id": 1234,
        "device_type": "level",
        "title": "Test Response Level",
- [1]   "version": "100",
+ [1]   "version": 100,
        "lat": None,
        "lng": None,
        "address": None,
- [2]   "status": "Working",
+ [2]   "status": "working",
+ [2]   "status_number": 2,
        "delivery_notes": None,
        "units": "US Imperial",
        "reported": "Jul 15th, 1:25 PM",
        "tx_reported": "Jul 15th, 8:17 AM",
        "last_updated_on": None,
- [1]   "wifi_signal": "100%",
+ [1]   "wifi_signal": 100,
- [1]   "tx_signal": "-46.00dBm",
+ [1]   "tx_signal": -46.00,
        "percent_level": 50,
        "battery_voltage": 6.6,
- [2]   "battery_status": "Good",
+ [2]   "battery_status": "good",
+ [2]   "battery_status_number": 1,
- [3]   "volume_level": 100,
+ [3]   "volume_level": 378.541178,
- [3]   "inch_level": 10,
+ [3]   "inch_level": 0.254,
        "enclosure_temperature": 22.2,
- [3]   "probe_temperature": 70,
+ [3]   "probe_temperature": 21.111,
        "depth": 10,
        "power_x": 30,
        "power_y": 3048,
        "power_z": 24,
        "shape": "rectangle",
        "diameter": None,
        "width": None,
        "length": None,
        "temperature_units": "F",
    }
}
```
### Notes:
- [1] These values have been stripped of all chars and converted to int.
- [2] These values have been replaced with snake case equivalents and add a corresponding numeric id for each.
- [3] These values have been updated to convert their values to metric. The starting value depends on the `units` or `temperature_units` parameter. These values are rounded to the nearest 6 digits, and 3 digits for temperatures.
# Improvements
The library now handles the conversion of the readings to a standard format. Removing the need to do conversions or unit handling in the project that utilizes this library. Reducing code complexity.