### PR TITLE
Remove unused Cython build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3.0.2', 'versioningit']
+requires = ['setuptools>=65.4.1', 'wheel', 'versioningit']
 
 [project]
 name = "aioptdevices"


### PR DESCRIPTION
aioptdevices is pure Python, so Cython is not used by the build. This removes the leftover template dependency.

Context: https://github.com/NixOS/nixpkgs/pull/529027#discussion_r3406061123